### PR TITLE
Improve chatwoot client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Chatwoot Client Demo
+
+This project contains a simple HTML page that loads the Chatwoot widget and automatically opens any existing conversation for the current visitor.
+
+## Usage
+
+1. Serve `index.html` from any static web server.
+2. Adjust the following constants in `index.html` to match your Chatwoot installation:
+   - `CHATWOOT_BASE` – the base URL of your Chatwoot instance.
+   - `WEBSITE_TOKEN` – the website token generated in Chatwoot.
+3. Open the page in your browser. If a `uid` query parameter is present, that value is used as the visitor ID. Otherwise a UUID is stored in `localStorage` so returning visitors see their previous conversation.
+
+## Development
+
+You can launch a basic server with Python for local testing:
+
+```bash
+python3 -m http.server 8080
+```
+
+Then browse to <http://localhost:8080>.
+
+## License
+
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
         });
 
         // 3b. Identify the visitor (writes cw_user_<id> & cw_conversation cookies under the hood)
-        window.$chatwoot.setUser("13123213", {
+        window.$chatwoot.setUser(contactId, {
           name: "Alice Doe",
           email: "alice@example.com"
         });


### PR DESCRIPTION
## Summary
- fix widget setup by using the generated contactId
- add a newline at end of index.html
- document how to configure and run the demo

## Testing
- `python3 -m http.server 8080` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414d0a0624832da55b9d7137681c43