### PR TITLE
Persist uid parameter in localStorage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 CHATWOOT_BASE=http://192.168.80.16:3000/
 WEBSITE_TOKEN=aj7CtUohDRR3w7ybAwvXzGbM
+# Optional: precomputed identifier hash for verified users
+IDENTIFIER_HASH=

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ This project contains a simple HTML page that loads the Chatwoot widget and auto
 
    Both values are read from `.env` at runtime. `WEBSITE_TOKEN` can be overridden by a `token` query parameter if needed.
 3. Open the page in your browser. If a `uid` query parameter is present, that value is used as the visitor ID and persisted in `localStorage`. Otherwise a UUID is generated and stored so returning visitors see their previous conversation.
-   
-   If you load the page without a `uid`, the script automatically appends the generated ID to the URL. Copy this URL to access the same conversation from a different browser or device.
+
+   If you load the page without a `uid`, the script automatically appends the generated ID to the URL. Copy this URL to access the same conversation from another browser.
+
+   The widget now also stores the conversation ID in `localStorage` and restores it when the same `uid` is used, so chats truly continue across browsers or devices.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ This project contains a simple HTML page that loads the Chatwoot widget and auto
 2. Copy `.env.example` to `.env` and adjust the values to match your Chatwoot installation:
    - `CHATWOOT_BASE` – the base URL of your Chatwoot instance.
    - `WEBSITE_TOKEN` – the website token generated in Chatwoot.
+   - `IDENTIFIER_HASH` – optional hash to verify the visitor when calling `setUser`.
 
-   Both values are read from `.env` at runtime. `WEBSITE_TOKEN` can be overridden by a `token` query parameter if needed.
+   The values above are read from `.env` at runtime. `WEBSITE_TOKEN` and `IDENTIFIER_HASH` can be overridden by `token` and `hash` query parameters if needed.
 3. Open the page in your browser. If a `uid` query parameter is present, that value is used as the visitor ID and persisted in `localStorage`. Otherwise a UUID is generated and stored so returning visitors see their previous conversation.
 
    If you load the page without a `uid`, the script automatically appends the generated ID to the URL. Copy this URL to access the same conversation from another browser.
 
-   The widget now also stores the conversation ID in `localStorage` and restores it when the same `uid` is used, so chats truly continue across browsers or devices.
+   The widget also stores the conversation ID in `localStorage` and restores it when the same `uid` is used. Providing the same `uid` and matching `hash` lets Chatwoot reopen the conversation in any browser or device.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project contains a simple HTML page that loads the Chatwoot widget and auto
 
    If you load the page without a `uid`, the script automatically appends the generated ID to the URL. Copy this URL to access the same conversation from another browser.
 
-   The widget also stores the conversation ID in `localStorage` and restores it when the same `uid` is used. Providing the same `uid` and matching `hash` lets Chatwoot reopen the conversation in any browser or device.
+   The widget also stores the conversation ID in `localStorage` and reflects it in the page URL using a `cid` query parameter. Copy the URL containing both `uid` and `cid` to continue the same conversation from another browser. A matching `hash` is still recommended when verifying visitors.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This project contains a simple HTML page that loads the Chatwoot widget and auto
 
    Both values are read from `.env` at runtime. `WEBSITE_TOKEN` can be overridden by a `token` query parameter if needed.
 3. Open the page in your browser. If a `uid` query parameter is present, that value is used as the visitor ID and persisted in `localStorage`. Otherwise a UUID is generated and stored so returning visitors see their previous conversation.
+   
+   If you load the page without a `uid`, the script automatically appends the generated ID to the URL. Copy this URL to access the same conversation from a different browser or device.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project contains a simple HTML page that loads the Chatwoot widget and auto
    - `WEBSITE_TOKEN` – the website token generated in Chatwoot.
 
    Both values are read from `.env` at runtime. `WEBSITE_TOKEN` can be overridden by a `token` query parameter if needed.
-3. Open the page in your browser. If a `uid` query parameter is present, that value is used as the visitor ID. Otherwise a UUID is stored in `localStorage` so returning visitors see their previous conversation.
+3. Open the page in your browser. If a `uid` query parameter is present, that value is used as the visitor ID and persisted in `localStorage`. Otherwise a UUID is generated and stored so returning visitors see their previous conversation.
 
 ## Development
 

--- a/index.html
+++ b/index.html
@@ -102,6 +102,13 @@
       const queryId = getChatwootIdFromQuery();
       const contactId = getOrCreateChatwootId(queryId);
 
+      // If no uid was supplied in the query string, add the generated id to the URL
+      if (!queryId) {
+        const url = new URL(window.location);
+        url.searchParams.set('uid', contactId);
+        window.history.replaceState({}, '', url);
+      }
+
       // 2. Inject the Chatwoot SDK script
       const script = document.createElement("script");
       script.src = CHATWOOT_BASE + "/packs/js/sdk.js";

--- a/index.html
+++ b/index.html
@@ -91,6 +91,27 @@
     }
 
 
+    function getCookie(name) {
+      const match = document.cookie
+        .split('; ')
+        .find((c) => c.startsWith(name + '='));
+      return match ? match.split('=')[1] : null;
+    }
+
+    function setCookie(name, value) {
+      document.cookie = name + '=' + value + '; path=/';
+    }
+
+    function getConversationCookieName(token) {
+      const base = 'cw_conversation';
+      const withToken = base + '_' + token;
+      const cookies = document.cookie.split('; ');
+      if (cookies.some((c) => c.startsWith(withToken + '='))) {
+        return withToken;
+      }
+      return base;
+    }
+
     function initChatwoot(env) {
       const CHATWOOT_BASE = env.CHATWOOT_BASE;
       const WEBSITE_TOKEN = getChatwootTokenFromQuery() || env.WEBSITE_TOKEN;
@@ -101,6 +122,13 @@
       // 4. First check query param, then fallback to .env
       const queryId = getChatwootIdFromQuery();
       const contactId = getOrCreateChatwootId(queryId);
+      const convStoreKey = 'chatwoot_conversation_' + contactId;
+
+      const convId = localStorage.getItem(convStoreKey);
+      if (convId) {
+        const cookieName = getConversationCookieName(WEBSITE_TOKEN);
+        setCookie(cookieName, convId);
+      }
 
       // If no uid was supplied in the query string, add the generated id to the URL
       if (!queryId) {
@@ -138,6 +166,12 @@
         window.$chatwoot.toggle();
         const styleEl = document.getElementById('style');
         document.body.appendChild(styleEl.cloneNode(true));
+
+        const cookieName = getConversationCookieName(WEBSITE_TOKEN);
+        const cid = getCookie(cookieName);
+        if (cid) {
+          localStorage.setItem(convStoreKey, cid);
+        }
 
       });
     }

--- a/index.html
+++ b/index.html
@@ -43,10 +43,15 @@
       return params.get("uid");
     }
 
-    function getChatwootTokenFromQuery() {
-      const params = new URLSearchParams(window.location.search);
-      return params.get("token");
-    }
+      function getChatwootTokenFromQuery() {
+        const params = new URLSearchParams(window.location.search);
+        return params.get("token");
+      }
+
+      function getIdentifierHashFromQuery() {
+        const params = new URLSearchParams(window.location.search);
+        return params.get("hash");
+      }
 
     // 2. Load environment defaults from .env if present
     function loadEnv() {
@@ -115,6 +120,7 @@
     function initChatwoot(env) {
       const CHATWOOT_BASE = env.CHATWOOT_BASE;
       const WEBSITE_TOKEN = getChatwootTokenFromQuery() || env.WEBSITE_TOKEN;
+      const identifierHash = getIdentifierHashFromQuery() || env.IDENTIFIER_HASH;
       if (!CHATWOOT_BASE || !WEBSITE_TOKEN) {
         console.error('CHATWOOT_BASE or WEBSITE_TOKEN missing in .env');
         return;
@@ -150,10 +156,14 @@
         });
 
         // 3b. Identify the visitor (writes cw_user_<id> & cw_conversation cookies under the hood)
-        window.$chatwoot.setUser(contactId, {
+        const userInfo = {
           name: "Alice Doe",
           email: "alice@example.com"
-        });
+        };
+        if (identifierHash) {
+          userInfo.identifier_hash = identifierHash;
+        }
+        window.$chatwoot.setUser(contactId, userInfo);
 
       };
 

--- a/index.html
+++ b/index.html
@@ -66,8 +66,15 @@
     }
 
     // 3. Generate or reuse a UUID in localStorage so we get a stable contactId
-    function getOrCreateChatwootId() {
+    function getOrCreateChatwootId(preferredId) {
       let id = localStorage.getItem("chatwoot_contact_id");
+
+      if (preferredId) {
+        id = preferredId;
+        localStorage.setItem("chatwoot_contact_id", id);
+        return id;
+      }
+
       if (!id) {
         if (crypto && typeof crypto.randomUUID === "function") {
           id = crypto.randomUUID();
@@ -93,7 +100,7 @@
       }
       // 4. First check query param, then fallback to .env
       const queryId = getChatwootIdFromQuery();
-      const contactId = queryId || getOrCreateChatwootId();
+      const contactId = getOrCreateChatwootId(queryId);
 
       // 2. Inject the Chatwoot SDK script
       const script = document.createElement("script");

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
       return params.get("uid");
     }
 
-      function getChatwootTokenFromQuery() {
+    function getChatwootTokenFromQuery() {
         const params = new URLSearchParams(window.location.search);
         return params.get("token");
       }
@@ -51,6 +51,11 @@
       function getIdentifierHashFromQuery() {
         const params = new URLSearchParams(window.location.search);
         return params.get("hash");
+      }
+
+      function getConversationIdFromQuery() {
+        const params = new URLSearchParams(window.location.search);
+        return params.get("cid");
       }
 
     // 2. Load environment defaults from .env if present
@@ -130,10 +135,12 @@
       const contactId = getOrCreateChatwootId(queryId);
       const convStoreKey = 'chatwoot_conversation_' + contactId;
 
-      const convId = localStorage.getItem(convStoreKey);
+      const queryCid = getConversationIdFromQuery();
+      let convId = queryCid || localStorage.getItem(convStoreKey);
       if (convId) {
         const cookieName = getConversationCookieName(WEBSITE_TOKEN);
         setCookie(cookieName, convId);
+        localStorage.setItem(convStoreKey, convId);
       }
 
       // If no uid was supplied in the query string, add the generated id to the URL
@@ -181,6 +188,11 @@
         const cid = getCookie(cookieName);
         if (cid) {
           localStorage.setItem(convStoreKey, cid);
+          const url = new URL(window.location);
+          if (url.searchParams.get('cid') !== cid) {
+            url.searchParams.set('cid', cid);
+            window.history.replaceState({}, '', url);
+          }
         }
 
       });


### PR DESCRIPTION
## Summary
- persist the `uid` query parameter as the contact ID
- use the stored id for later visits
- document the updated behaviour in the README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68415a7fec28832d92cf8d86daeffbbb